### PR TITLE
{cmake} Declare include directories as SYSTEM

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(rapidobj::rapidobj ALIAS rapidobj)
 
 target_compile_features(rapidobj INTERFACE cxx_std_17)
 
-target_include_directories(rapidobj INTERFACE
+target_include_directories(rapidobj SYSTEM INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${RAPIDOBJ_INCLUDE_DIR}>
 )


### PR DESCRIPTION
This allows consumers of the header to ignore all the warnings so `-Werror` may be used.

See: https://cmake.org/cmake/help/latest/command/target_include_directories.html

(If you would rather I go through and fix the warnings I can work on that. Looks like it's mostly shadowed vars and unused vars in `if` statements.)